### PR TITLE
Allow local builds and loading pojo's

### DIFF
--- a/kernels/micro/src/main/java/jadex/micro/features/impl/MicroLifecycleComponentFeature.java
+++ b/kernels/micro/src/main/java/jadex/micro/features/impl/MicroLifecycleComponentFeature.java
@@ -400,7 +400,8 @@ public class MicroLifecycleComponentFeature extends	AbstractComponentFeature imp
 			Method	method	= null;
 			try
 			{
-				method	= mi.getMethod(component.getClassLoader());
+				Object pojo = component.getFeature(IPojoComponentFeature.class).getPojoAgent();
+				method = mi.getMethod(pojo.getClass().getClassLoader());
 				
 				// Try to guess parameters from given args or component internals.
 				IParameterGuesser	guesser	= args!=null ? new SimpleParameterGuesser(component.getParameterGuesser(), Arrays.asList(args)) : component.getParameterGuesser();
@@ -414,7 +415,7 @@ public class MicroLifecycleComponentFeature extends	AbstractComponentFeature imp
 				{
 					// It is now allowed to use protected/private agent created, body, terminate methods
 					method.setAccessible(true);
-					Object res = method.invoke(component.getFeature(IPojoComponentFeature.class).getPojoAgent(), iargs);
+					Object res = method.invoke(pojo, iargs);
 					if(res instanceof IFuture)
 					{
 						ret	= (IFuture<Void>)res;

--- a/src/main/buildutils/publishing.gradle
+++ b/src/main/buildutils/publishing.gradle
@@ -1,4 +1,4 @@
-//apply plugin: 'maven-publish'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'de.marcphilipp.nexus-publish'
 
@@ -268,6 +268,17 @@ publishing {
         	}
 		}
 	}
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
 }
 
 if(canSign) {


### PR DESCRIPTION
These changes allow me to build a local version of jadex (#5).
Additionally, while chasing down how to use my custom classloader (#4) and self-constructed Agent classes (#6),I ran into an issue where the classloader for the component only knew how to load AOT-compiled classes, and was not able to see/find dynamically redefined classes. 

This should never be a problem for a Java/Kotlin project AFAIK, but severely limits the usefulness of using stuff such as Clojure. If it doesn't negatively impact other parts of the codebase, I'd appreciate this change being upstreamed as well.

If you want/need me to sign a CLA, please let me know.