### PR TITLE
Use 'file:'-url without decoding first.

### DIFF
--- a/util/commons/src/main/java/jadex/commons/SUtil.java
+++ b/util/commons/src/main/java/jadex/commons/SUtil.java
@@ -1380,7 +1380,11 @@ public class SUtil
 
 					try
 					{
-						file = new File(URLDecoder.decode(url.getFile(), encoding)); // does only work since 1.4.
+						file = new File(url.getFile());
+						if (!file.exists()) {
+							file = new File(URLDecoder.decode(url.getFile(), encoding)); // does only work since 1.4.
+						}
+
 						// file = new File(URLDecoder.decode(url.getFile())); //
 						// problem decode is deprecated.
 						if(file.exists())


### PR DESCRIPTION
In my testing harness, my classpath contained a `+`, which was removed by decoding this path with the `URLDecoder`. This commit changes this to first see if the 'raw' path already resolves to an existing file or directory.

